### PR TITLE
Fix crash when switching theme

### DIFF
--- a/app/libs/actionBarPullToRefresh/src/main/java/uk/co/senab/actionbarpulltorefresh/library/PullToRefreshAttacher.java
+++ b/app/libs/actionBarPullToRefresh/src/main/java/uk/co/senab/actionbarpulltorefresh/library/PullToRefreshAttacher.java
@@ -756,10 +756,17 @@ public class PullToRefreshAttacher implements View.OnTouchListener {
             super(context);
 
             // Move all children from decor view to here
-            for (int i = 0, z = systemDecorView.getChildCount(); i < z; i++) {
+            int systemDecorViewChildCnt = systemDecorView.getChildCount();
+            for (int i = 0; i < systemDecorViewChildCnt; i++) {
                 View child = systemDecorView.getChildAt(i);
-                systemDecorView.removeView(child);
-                addView(child);
+
+                if (child != null) {
+                    systemDecorView.removeView(child);
+                    addView(child);
+                }
+
+                // cnt has to be updated because statements above may modify it
+                systemDecorViewChildCnt = systemDecorView.getChildCount();
             }
 
             /**


### PR DESCRIPTION
fixes #1 

the problem was the for loop

by the `systemDecorView.removeView(child)` statement the `systemDecorView.getChildCount()` changed, but the z variable wasn't updated
so at some point the `systemDecorView.getChildAt(i)` got out of bounds and returned null what caused the error

additionally added a null check to be sure

should work now